### PR TITLE
Update all workflows to use Node 20 dependencies

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -47,14 +47,14 @@ jobs:
       JULIA_NUM_THREADS: ${{ matrix.threads }}
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: "1"
           show-versioninfo: true
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: Install dependencies
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/.github/workflows/FormatCheck.yaml
+++ b/.github/workflows/FormatCheck.yaml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - "**/*.jl"
-      - ".github/workflows/FormatCheck.yml"
+      - ".github/workflows/FormatCheck.yaml"
 jobs:
   format-check:
     name: Julia
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: "1"
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: Install JuliaFormatter
         shell: julia --project=@format --color=yes {0}
         run: |
@@ -40,7 +40,7 @@ jobs:
           using JuliaFormatter
           format("."; verbose=true) || exit(1)
       # Add formatting suggestions to non-draft PRs even if when "Check formatting" fails
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@185c9c06d0a28fbe43b50aca4b32777b649e7cbd # v1.12.0
         if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
         with:
           tool_name: JuliaFormatter


### PR DESCRIPTION
Updates the CI dependencies of this repo to be versions using Node 20 as Node 16 is EOL and GHAs using it will stop working May 13th.