### PR TITLE
Allow `graceful_terminator` to bind to an old named pipe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "K8sDeputy"
 uuid = "2481ae95-212f-4650-bb21-d53ea3caf09f"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/K8sDeputy.jl
+++ b/src/K8sDeputy.jl
@@ -10,5 +10,6 @@ export Deputy, graceful_terminator, readied!, shutdown!, graceful_terminate
 include("graceful_termination.jl")
 include("health.jl")
 include("server.jl")
+include("deprecated.jl")
 
 end # module K8sDeputy

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,3 @@
+using Base: @deprecate
+
+@deprecate graceful_terminate(pid::Integer; wait::Bool=true) graceful_terminate(Int32(pid); wait) true

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,5 @@
 using Base: @deprecate
 
-@deprecate graceful_terminate(pid::Integer; wait::Bool=true) graceful_terminate(Int32(pid); wait) true
+@deprecate(graceful_terminate(pid::Integer; wait::Bool=true),
+           graceful_terminate(Int32(pid); wait),
+           true)

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -13,7 +13,8 @@ _deputy_ipc_dir() = get(tempdir, ENV, "DEPUTY_IPC_DIR")
 
 # Prefer using UNIX domain sockets but if the `DEPUTY_IPC_DIR` is set assume the file
 # system is read-only and use a named pipe instead.
-function _socket_path(name)
+function _graceful_terminator_socket_path(pid::Int32)
+    name = "graceful-terminator.$pid"
     return haskey(ENV, "DEPUTY_IPC_DIR") ? joinpath(_deputy_ipc_dir(), name) : name
 end
 
@@ -80,11 +81,19 @@ process and the `preStop` process to cleanly terminate.
 function graceful_terminator(f; set_entrypoint::Bool=true)
     set_entrypoint && set_entrypoint_pid(getpid())
 
-    # Utilize UNIX domain sockets for the IPC. Avoid using network sockets here as we don't
-    # want to allow access to this functionality from outside of the localhost. Each process
-    # uses a distinct socket name allowing for multiple Julia processes to allow independent
-    # use of the graceful terminator.
-    server = listen(_socket_path("graceful-terminator.$(getpid())"))
+    # Utilize UNIX domain sockets or named pipes for the IPC. Avoid using network sockets
+    # here as we don't want to allow access to this functionality from outside of the
+    # localhost. Each process uses a distinct socket name allowing for multiple Julia
+    # processes to allow independent use of the graceful terminator.
+    socket_path = _graceful_terminator_socket_path(getpid())
+
+    # Remove any pre-existing named pipe as otherwise this will cause our `listen` call to
+    # fail. Should be safe to remove this file as it has been reserved for this PID. Only
+    # should be needed in the scenarion where the K8s pod has been restarted and the
+    # location of the socket exists in a K8s volume.
+    ispath(socket_path) && rm(socket_path)
+
+    server = listen(socket_path)
 
     t = Threads.@spawn begin
         while isopen(server)
@@ -131,7 +140,7 @@ function graceful_terminate(pid::Int32=entrypoint_pid(); wait::Bool=true)
     #     println(io, "preStop called")
     # end
 
-    sock = connect(_socket_path("graceful-terminator.$pid"))
+    sock = connect(_graceful_terminator_socket_path(pid))
     println(sock, "terminate")
     close(sock)
 

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -89,7 +89,7 @@ function graceful_terminator(f; set_entrypoint::Bool=true)
 
     # Remove any pre-existing named pipe as otherwise this will cause our `listen` call to
     # fail. Should be safe to remove this file as it has been reserved for this PID. Only
-    # should be needed in the scenarion where the K8s pod has been restarted and the
+    # should be needed in the scenario where the K8s pod has been restarted and the
     # location of the socket exists in a K8s volume.
     ispath(socket_path) && rm(socket_path)
 

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -24,7 +24,7 @@ set_entrypoint_pid(pid::Integer) = write(entrypoint_pid_file(), string(pid) * "\
 
 function entrypoint_pid()
     pid_file = entrypoint_pid_file()
-    return isfile(pid_file) ? parse(Int, readchomp(pid_file)) : 1
+    return isfile(pid_file) ? parse(Int32, readchomp(pid_file)) : Int32(1)
 end
 
 # https://docs.libuv.org/en/v1.x/process.html#c.uv_kill
@@ -115,12 +115,12 @@ function graceful_terminator(f; set_entrypoint::Bool=true)
 end
 
 """
-    graceful_terminate(pid::Integer=entrypoint_pid(); wait::Bool=true) -> Nothing
+    graceful_terminate(pid::Int32=entrypoint_pid(); wait::Bool=true) -> Nothing
 
 Initiates the execution of the `graceful_terminator` user callback in the process `pid`. See
 `graceful_terminator` for more details.
 """
-function graceful_terminate(pid::Integer=entrypoint_pid(); wait::Bool=true)
+function graceful_terminate(pid::Int32=entrypoint_pid(); wait::Bool=true)
     # Note: The follow dead code has been left here purposefully as an example of how to
     # view output when running via `preStop`.
     #


### PR DESCRIPTION
Fixes this failure:
```julia
ERROR: LoadError: ArgumentError: could not listen on path /mnt/deputy-ipc/graceful-terminator.7
Stacktrace:
 [1] listen(path::String)
   @ Sockets /usr/local/julia/share/julia/stdlib/v1.9/Sockets/src/PipeServer.jl:79
 [2] graceful_terminator(f::var"#3#4"; set_entrypoint::Bool)
   @ K8sDeputy /usr/local/share/julia-depot/41c7a7947d/packages/K8sDeputy/tvrDX/src/graceful_termination.jl:87
 [3] graceful_terminator(f::Function)
   @ K8sDeputy /usr/local/share/julia-depot/41c7a7947d/packages/K8sDeputy/tvrDX/src/graceful_termination.jl:80
 [4] top-level scope
   ...
```
Only appears to occur when using `DEPUTY_IPC_DIR` and targeting a K8s volume which persists between restarts. Even an `emptyDir` persists for the lifetime of the pod.