### PR TITLE
Ensure pid directory exists

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "K8sDeputy"
 uuid = "2481ae95-212f-4650-bb21-d53ea3caf09f"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -21,7 +21,11 @@ end
 # Following the Linux convention for pid files:
 # https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html
 entrypoint_pid_file() = joinpath(_deputy_ipc_dir(), "julia-entrypoint.pid")
-set_entrypoint_pid(pid::Integer) = write(entrypoint_pid_file(), string(pid) * "\n")
+function set_entrypoint_pid(pid::Integer)
+    file = entrypoint_pid_file()
+    mkpath(dirname(file))
+    return write(file, string(pid) * "\n")
+end
 
 function entrypoint_pid()
     pid_file = entrypoint_pid_file()


### PR DESCRIPTION
If `DEPUTY_IPD_DIR` points to a non-existent directory, then
`graceful_terminator` will fail with a write error.  This adds a `mkpath` before
`write` to try to ensure that the directory exists before we try writing there.