### PR TITLE
use tempdir for graceful terminator socket when env not set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "K8sDeputy"
 uuid = "2481ae95-212f-4650-bb21-d53ea3caf09f"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -13,9 +13,8 @@ _deputy_ipc_dir() = get(tempdir, ENV, "DEPUTY_IPC_DIR")
 
 # Prefer using UNIX domain sockets but if the `DEPUTY_IPC_DIR` is set assume the file
 # system is read-only and use a named pipe instead.
-function _graceful_terminator_socket_path(pid::Int32)
-    name = "graceful-terminator.$pid"
-    return haskey(ENV, "DEPUTY_IPC_DIR") ? joinpath(_deputy_ipc_dir(), name) : name
+function _graceful_terminator_socket_path(pid::Int32) =
+    return joinpath(_deputy_ipc_dir(), "graceful-terminator.$pid")
 end
 
 # Following the Linux convention for pid files:

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -13,7 +13,7 @@ _deputy_ipc_dir() = get(tempdir, ENV, "DEPUTY_IPC_DIR")
 
 # Prefer using UNIX domain sockets but if the `DEPUTY_IPC_DIR` is set assume the file
 # system is read-only and use a named pipe instead.
-function _graceful_terminator_socket_path(pid::Int32) =
+function _graceful_terminator_socket_path(pid::Int32)
     return joinpath(_deputy_ipc_dir(), "graceful-terminator.$pid")
 end
 


### PR DESCRIPTION
This makes the socket path more robust to images where the workdir is set to
something that's read-only.