### PR TITLE
Use `/run` as the default for PID/UNIX-domain sockets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "K8sDeputy"
 uuid = "2481ae95-212f-4650-bb21-d53ea3caf09f"
 authors = ["Beacon Biosignals, Inc"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/graceful_termination.md
+++ b/docs/src/graceful_termination.md
@@ -93,31 +93,3 @@ spec:
       emptyDir:
         medium: Memory
 ```
-
-Alternatively, if you don't want to specify the write location for these IPC files you can use the `DEPUTY_IPC_DIR` environmental variable:
-
-```yaml
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-    - name: app
-      # command: ["/bin/sh", "-c", "julia entrypoint.jl; sleep 1"]
-      env:
-        - name: DEPUTY_IPC_DIR
-          value: /mnt/deputy-ipc
-      lifecycle:
-        preStop:
-          exec:
-            command: ["julia", "-e", "using K8sDeputy; graceful_terminate()"]
-      securityContext:
-        readOnlyRootFilesystem: true
-      volumeMounts:
-        - name: deputy-ipc
-          mountPath: /mnt/deputy-ipc
-          subPath: app  # Set the `subPath` to the container name to ensure per-container isolation
-  volumes:
-    - name: deputy-ipc
-      emptyDir:
-        medium: Memory
-```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -27,9 +27,6 @@ For users who want to get started quickly you can use the following template to 
      containers:
        - name: app
          command: ["/bin/sh", "-c", "julia entrypoint.jl; sleep 1"]
-         env:
-           - name: DEPUTY_IPC_DIR
-             value: /mnt/deputy-ipc
          ports:
            - name: health-check
              containerPort: 8081  # Default K8sDeputy.jl heath check port
@@ -54,11 +51,12 @@ For users who want to get started quickly you can use the following template to 
                - all
            readOnlyRootFilesystem: true
          volumeMounts:
-           - mountPath: /mnt/deputy-ipc
-             name: deputy-ipc
+           - name: ipc
+              mountPath: /run
+              subPath: app  # Set the `subPath` to the container name to ensure per-container isolation
      terminationGracePeriodSeconds: 30
      volumes:
-       - name: deputy-ipc
+       - name: ipc
          emptyDir:
            medium: Memory
    ```

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -7,14 +7,15 @@
 # from experimenting with this there are a few issues such as being unable to use locks or
 # printing (`jl_safe_printf` does work).
 
-# Linux typically stores PID files in `/run` which requires root access. For systems with
-# read-only file systems we need to support a user specified writable volume.
+# Linux stores PID files and UNIX-domain sockets in `/run`. Users with K8s containers
+# utilizing read-only file systems should make use of a volume mount to allow K8sDeputy.jl
+# to write to `/run`. Users can change the IPC directory by specifying `DEPUTY_IPC_DIR` but
+# this is mainly just used for testing.
 _deputy_ipc_dir() = get(ENV, "DEPUTY_IPC_DIR", "/run")
 
 # Write transient UNIX-domain sockets to the IPC directory.
 function _graceful_terminator_socket_path(pid::Int32)
-    name = "graceful-terminator.$pid.sock"
-    return joinpath(_deputy_ipc_dir(), name)
+    return joinpath(_deputy_ipc_dir(), "graceful-terminator.$pid.sock")
 end
 
 # Following the Linux convention for pid files:

--- a/src/graceful_termination.jl
+++ b/src/graceful_termination.jl
@@ -15,7 +15,7 @@ _deputy_ipc_dir() = get(ENV, "DEPUTY_IPC_DIR", "/run")
 
 # Write transient UNIX-domain sockets to the IPC directory.
 function _graceful_terminator_socket_path(pid::Int32)
-    return joinpath(_deputy_ipc_dir(), "graceful-terminator.$pid.sock")
+    return joinpath(_deputy_ipc_dir(), "graceful-terminator.$pid.socket")
 end
 
 # Following the Linux convention for pid files:

--- a/test/graceful_termination.jl
+++ b/test/graceful_termination.jl
@@ -116,7 +116,7 @@
 
         # Socket exists as a UNIX-domain socket
         socket_path = withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
-            K8sDeputy._graceful_terminator_socket_path(getpid(p))
+            return K8sDeputy._graceful_terminator_socket_path(getpid(p))
         end
         @test ispath(socket_path)
         @test !isfile(socket_path)

--- a/test/graceful_termination.jl
+++ b/test/graceful_termination.jl
@@ -1,4 +1,6 @@
 @testset "graceful_terminator" begin
+    deputy_ipc_dir = mktempdir()
+
     @testset "Julia entrypoint" begin
         code = quote
             using K8sDeputy
@@ -12,6 +14,7 @@
         end
 
         cmd = `$(Base.julia_cmd()) --color=no -e $code`
+        cmd = addenv(cmd, "DEPUTY_IPC_DIR" => deputy_ipc_dir)
         buffer = IOBuffer()
         p = run(pipeline(cmd; stdout=buffer, stderr=buffer); wait=false)
         @test timedwait(() -> process_running(p), Second(5)) === :ok
@@ -21,7 +24,9 @@
 
         # When no PID is passed in the process ID is read from the Julia entrypoint file.
         # Blocks untils the process terminates.
-        @test graceful_terminate() === nothing
+        withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
+            @test graceful_terminate() === nothing
+        end
 
         @test process_exited(p)
         @test p.exitcode == 2
@@ -47,6 +52,7 @@
         end
 
         cmd = `$(Base.julia_cmd()) --color=no -e $code`
+        cmd = addenv(cmd, "DEPUTY_IPC_DIR" => deputy_ipc_dir)
         buffer1 = IOBuffer()
         buffer2 = IOBuffer()
         p1 = run(pipeline(cmd; stdout=buffer1, stderr=buffer1); wait=false)
@@ -57,8 +63,10 @@
         sleep(3)
 
         # Blocks untils the process terminates
-        @test graceful_terminate(getpid(p1)) === nothing
-        @test graceful_terminate(getpid(p2)) === nothing
+        withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
+            @test graceful_terminate(getpid(p1)) === nothing
+            @test graceful_terminate(getpid(p2)) === nothing
+        end
         @test process_exited(p1)
         @test process_exited(p2)
 
@@ -73,10 +81,9 @@
     end
 
     # When users set `DEPUTY_IPC_DIR` they may be using a K8s volume. As even `emptyDir`
-    # volumes persist for the lifetime of the pod we may have a named pipe already present
-    # from a previous restart.
+    # volumes persist for the lifetime of the pod we may have a UNIX-domain socket already
+    # present from a previous restart.
     @testset "bind after restart" begin
-        deputy_ipc_dir = mktempdir()
         code = quote
             using K8sDeputy
             using Sockets: listen
@@ -99,31 +106,33 @@
         end
 
         cmd = `$(Base.julia_cmd()) --color=no -e $code`
+        cmd = addenv(cmd, "DEPUTY_IPC_DIR" => deputy_ipc_dir)
+        buffer = IOBuffer()
+        p = run(pipeline(cmd; stdout=buffer, stderr=buffer); wait=false)
+        @test timedwait(() -> process_running(p), Second(5)) === :ok
 
-        withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
-            buffer = IOBuffer()
-            p = run(pipeline(cmd; stdout=buffer, stderr=buffer); wait=false)
-            @test timedwait(() -> process_running(p), Second(5)) === :ok
+        # Allow some time for Julia to startup and the graceful terminator to be registered.
+        sleep(3)
 
-            # Allow some time for Julia to startup and the graceful terminator to be registered.
-            sleep(3)
-
-            # Socket exists as a named pipe
-            socket_path = K8sDeputy._graceful_terminator_socket_path(getpid(p))
-            @test ispath(socket_path)
-            @test !isfile(socket_path)
-
-            # Blocks untils the process terminates
-            @test graceful_terminate(getpid(p)) === nothing
-            @test process_exited(p)
-            @test p.exitcode == 2
-
-            output = String(take!(buffer))
-            expected = """
-                [ Info: GRACEFUL TERMINATION HANDLER
-                [ Info: SHUTDOWN COMPLETE
-                """
-            @test output == expected
+        # Socket exists as a UNIX-domain socket
+        socket_path = withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
+            K8sDeputy._graceful_terminator_socket_path(getpid(p))
         end
+        @test ispath(socket_path)
+        @test !isfile(socket_path)
+
+        # Blocks untils the process terminates
+        withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
+            @test graceful_terminate(getpid(p)) === nothing
+        end
+        @test process_exited(p)
+        @test p.exitcode == 2
+
+        output = String(take!(buffer))
+        expected = """
+            [ Info: GRACEFUL TERMINATION HANDLER
+            [ Info: SHUTDOWN COMPLETE
+            """
+        @test output == expected
     end
 end

--- a/test/health.jl
+++ b/test/health.jl
@@ -192,6 +192,7 @@ end
     end
 
     @testset "graceful termination" begin
+        deputy_ipc_dir = mktempdir()
         port = rand(EPHEMERAL_PORT_RANGE)
         code = quote
             using K8sDeputy, Sockets
@@ -211,6 +212,7 @@ end
         end
 
         cmd = `$(Base.julia_cmd()) --color=no -e $code`
+        cmd = addenv(cmd, "DEPUTY_IPC_DIR" => deputy_ipc_dir)
         buffer = IOBuffer()
         p = run(pipeline(cmd; stdout=buffer, stderr=buffer); wait=false)
         @test timedwait(() -> process_running(p), Second(5)) === :ok
@@ -220,7 +222,9 @@ end
         end === :ok
 
         # Blocks untils the process terminates
-        graceful_terminate(getpid(p))
+        withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
+            graceful_terminate(getpid(p))
+        end
         @test process_exited(p)
         @test p.exitcode == 1
 

--- a/test/health.jl
+++ b/test/health.jl
@@ -223,7 +223,7 @@ end
 
         # Blocks untils the process terminates
         withenv("DEPUTY_IPC_DIR" => deputy_ipc_dir) do
-            graceful_terminate(getpid(p))
+            return graceful_terminate(getpid(p))
         end
         @test process_exited(p)
         @test p.exitcode == 1


### PR DESCRIPTION
While reviewing #12 I needed to review when UNIX-domain sockets or named pipes were created. The answer seems to be [UNIX-domain sockets are created on Linux and macOS and only Windows creates named pipes](https://docs.libuv.org/en/v1.x/guide/processes.html#new-stdio-pipes). I also reviewed the [filesystem hierarchy standard (FHS) which states that `/run` should store both PID files and transient UNIX-domain sockets](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html) and realized that the `/run` directory could be made writable on read-only file systems with mounts which eliminated the need for `DEPUTY_IPC_DIR`.

Unfortunately, in order to allow for local testing of K8sDeputy.jl we need to keep `DEPUTY_IPC_DIR` around as normally `/run` is not writable by a normal user.

Supersedes #12. 